### PR TITLE
Adds ability to join open streak from open streaks controller

### DIFF
--- a/app/controllers/open_streaks_controller.rb
+++ b/app/controllers/open_streaks_controller.rb
@@ -18,7 +18,26 @@ class OpenStreaksController < ApplicationController
     if success
       render_jsonapi(streak, scope: false)
     else
-      render_errors_for(post)
+      render_errors_for(streak)
+    end
+  end
+
+  def update
+    streak, success = jsonapi_update.to_a
+
+    if success
+      render_jsonapi(streak, scope: false)
+    else
+      render_errors_for(streak)
+    end
+  end
+
+  def player_added(streak, old_player_count, new_player_count, player)
+    if new_player_count == Streak::MIN_PLAYERS
+      team_uuid = streak.players.map(&:id).sort.join
+      team = Team.find_or_create_by(uuid: team_uuid)
+      streak.update!(team: team)
+      streak.activate!
     end
   end
 end

--- a/app/models/streak.rb
+++ b/app/models/streak.rb
@@ -22,6 +22,7 @@ class Streak < ApplicationRecord
   has_many :players, through: :streak_players, after_add: :notify_on_player_add, after_remove: :notify_on_player_remove
 
   validates :status, presence: true
+  validates_uniqueness_of :team, conditions: -> { where(status: 'active')  }
   validate :minimum_number_of_players_for_active_streak
   validate :minimum_number_of_players_for_open_streak
   validate :team_presence_for_active_streak
@@ -44,6 +45,10 @@ class Streak < ApplicationRecord
 
     event :activate do
       transition :open => :active
+    end
+
+    before_transition any => :complete do |streak|
+      streak.completed_at = Time.zone.now
     end
 
     event :complete do

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,15 +4,28 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  name       :string
+#  uuid       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
 #  index_teams_on_name  (name) UNIQUE
+#  index_teams_on_uuid  (uuid)
 #
 
 class Team < ApplicationRecord
   has_many :team_players
   has_many :players, through: :team_players
+  has_many :streaks
+
+  # validate :only_one_active_streak_for_team
+
+  private
+
+  def only_one_active_streak_for_team
+    if streaks.active.count == 1
+      errors.add(:streaks, "Team can have only one active streak at a time")
+    end
+  end
 end

--- a/app/resources/streak_resource.rb
+++ b/app/resources/streak_resource.rb
@@ -2,6 +2,13 @@ class StreakResource < ApplicationResource
   type :streaks
   model Streak
 
+  def update(update_params)
+    instance = model.find(update_params.delete(:id))
+    instance.add_listener(context)
+    instance.update_attributes(update_params)
+    instance
+  end
+
   has_and_belongs_to_many :players,
     scope: -> { Player.all  },
     resource: PlayerResource,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
     end
   end
   resources :messages
-  resources :open_streaks, only: [:index, :create]
+  resources :open_streaks, only: [:index, :create, :update]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20180515042449_add_uuid_to_team.rb
+++ b/db/migrate/20180515042449_add_uuid_to_team.rb
@@ -1,0 +1,6 @@
+class AddUuidToTeam < ActiveRecord::Migration[5.2]
+  def change
+    add_column :teams, :uuid, :string, unique: true, null: false
+    add_index :teams, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_08_153621) do
+ActiveRecord::Schema.define(version: 2018_05_15_042449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,7 +73,9 @@ ActiveRecord::Schema.define(version: 2018_05_08_153621) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid", null: false
     t.index ["name"], name: "index_teams_on_name", unique: true
+    t.index ["uuid"], name: "index_teams_on_uuid"
   end
 
 end

--- a/spec/controllers/open_streaks_controller_spec.rb
+++ b/spec/controllers/open_streaks_controller_spec.rb
@@ -83,6 +83,139 @@ describe OpenStreaksController, type: :controller do
     end
   end
 
+  describe "PUT #update" do
+    it "reseponds successfully" do
+      # mock authenticated token
+      open_streak = create(:streak, :open, :with_players)
+      current_player = create(:player)
+      login_as(current_player)
+
+      patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+      expect(response).to be_success
+    end
+
+    it "adds a new player to the open streak" do
+      # mock authenticated token
+      open_streak = create(:streak, :open, :with_players)
+      current_player = create(:player)
+      login_as(current_player)
+
+      expect do
+        patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+      end.
+      to change { Player.find(current_player.id).streaks.count }.from(0).to(1)
+      expect(Streak.last.players).to include(current_player)
+    end
+
+    it "adds a current player to the open streak" do
+      # mock authenticated token
+      open_streak = create(:streak, :open, :with_players)
+      current_player = create(:player)
+      login_as(current_player)
+
+      expect do
+        patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+      end.
+      to change { StreakPlayer.count }.from(3).to(4)
+    end
+
+    context "when new player added to streak meets minimum players for streak" do
+
+      it "updates status for streak from open to active" do
+        open_streak = create(:streak, :open, :with_players, players_count: 5)
+        current_player = create(:player)
+        login_as(current_player)
+        expect do
+          patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+        end.
+        to change { open_streak.reload.status }.from("open").to("active")
+      end
+
+      context "when there is no team for new active streak players" do
+        it "creates a new team" do
+          open_streak = create(:streak, :open, :with_players, players_count: 5)
+          current_player = create(:player)
+          login_as(current_player)
+          expect do
+            patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+          end.
+          to change { Team.count }.from(0).to(1)
+        end
+
+        it "creates a new team with a uuid of the player ids sorted and joined" do
+          open_streak = create(:streak, :open, :with_players, players_count: 5)
+          current_player = create(:player)
+          login_as(current_player)
+          patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+          expect(open_streak.reload.team.uuid).to eq(open_streak.players.map(&:id).sort.join)
+        end
+      end
+
+      context "when there is already an active streak for the new streak's players" do
+        xit "is expected to be a failure" do
+          active_streak = create(:streak, :active)
+          open_streak = create(:streak, :open)
+          current_player = active_streak.players.first
+          open_streak.players << active_streak.players.select { |p| p != current_player }
+          login_as(current_player)
+
+            patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+          # expect(response).to be_success
+          expect(response.body).to eq({})
+        end
+      end
+
+      context "when there is already a team for players in the newly activated streak" do
+        it "does not create a new team" do
+          active_streak = create(:streak, :completed)
+          open_streak = create(:streak, :open)
+          current_player = active_streak.players.first
+          open_streak.players << active_streak.players.select { |p| p != current_player }
+          login_as(current_player)
+
+          expect do
+            patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+          end.
+          not_to change { Team.count }
+        end
+
+        it "adds the streak to the team that already has a completed streak for the players in the streak" do
+          #set up team with active streak
+          active_streak = create(:streak, :completed)
+
+          #set up open streak with all of the active streak players but one
+          open_streak = create(:streak, :open)
+          current_player = active_streak.players.first
+          open_streak.players << active_streak.players.select { |p| p != current_player }
+
+          #login as the one player missing from active streak's team
+          login_as(current_player)
+
+          # join the active streak
+          patch :update, params: join_active_streak_update_params(open_streak, current_player), format: :json
+
+          expect(open_streak.reload.team).to eq(active_streak.team)
+        end
+      end
+    end
+  end
+
+  def join_active_streak_update_params(open_streak, player)
+    {
+      id: open_streak.id,
+      "data": {
+        "type": "streaks",
+        "id": "#{open_streak.id}",
+        "relationships": {
+          "players": {
+            "data": { "type": "players", "id": "#{player.id}"  }
+          }
+        }
+      }
+    }
+  end
+
+
   def streak_params
     {
       "data": {

--- a/spec/factories/streaks.rb
+++ b/spec/factories/streaks.rb
@@ -40,10 +40,26 @@ FactoryBot.define do
     transient do
       players_count 6
     end
-    team
     after(:create) do |streak, options|
       create_list :player, (options.players_count), streaks: [streak]
     end
+    after(:create) do |streak|
+      create :team, uuid: streak.players.map(&:id).join, streaks: [streak]
+    end
     after(:create, &:activate!)
+  end
+
+  trait :completed do
+    transient do
+      players_count 6
+    end
+    after(:create) do |streak, options|
+      create_list :player, (options.players_count), streaks: [streak]
+    end
+    after(:create) do |streak|
+      create :team, uuid: streak.players.map(&:id).join, streaks: [streak]
+    end
+    after(:create, &:activate!)
+    after(:create, &:complete!)
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -4,16 +4,19 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  name       :string
+#  uuid       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
 #  index_teams_on_name  (name) UNIQUE
+#  index_teams_on_uuid  (uuid)
 #
 
 FactoryBot.define do
   factory :team do
     name "MyString"
+    sequence(:uuid) { |n| "team_uuid#{n}" }
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,16 +4,19 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  name       :string
+#  uuid       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
 #  index_teams_on_name  (name) UNIQUE
+#  index_teams_on_uuid  (uuid)
 #
 
 require 'rails_helper'
 
-RSpec.describe Team, type: :model do
+describe Team, type: :model do
   it { is_expected.to have_many(:players).through(:team_players) }
+  it { is_expected.to have_many(:streaks) }
 end


### PR DESCRIPTION
  - Adds the open streaks controller as listener to the streak model
  - When streak reach the minimum number of players for streak it finds or creates a team for the
    streak players and attaches it to streak AND then it activates the streak
  - Adds a string unique indexed uuid field for the team