### PR TITLE
Adds a max habits per day field to streak and validation when adding new habit

### DIFF
--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -2,11 +2,12 @@
 #
 # Table name: habits
 #
-#  id         :bigint(8)        not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  player_id  :integer
-#  streak_id  :integer
+#  id           :bigint(8)        not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  player_id    :integer
+#  streak_id    :integer
 #
 # Indexes
 #
@@ -16,4 +17,14 @@
 class Habit < ApplicationRecord
   belongs_to :player
   belongs_to :streak
+  validate :is_not_over_max_habits_per_day_for_streak
+
+  private
+
+  def is_not_over_max_habits_per_day_for_streak
+    count_of_habits_for_player_today = streak.habits.where(player_id: player.id).where('completed_at between ? AND ?', completed_at.beginning_of_day, completed_at.end_of_day).count 
+    if count_of_habits_for_player_today >= streak.max_habits_per_day
+      errors.add(:streak, "Can't add more than max habit per day for this streak")
+    end
+  end
 end

--- a/app/models/streak.rb
+++ b/app/models/streak.rb
@@ -2,17 +2,18 @@
 #
 # Table name: streaks
 #
-#  id              :bigint(8)        not null, primary key
-#  activated_at    :datetime
-#  completed_at    :datetime
-#  description     :text
-#  ended_at        :datetime
-#  habits_per_week :integer
-#  status          :string           default("open"), not null
-#  title           :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  team_id         :integer
+#  id                 :bigint(8)        not null, primary key
+#  activated_at       :datetime
+#  completed_at       :datetime
+#  description        :text
+#  ended_at           :datetime
+#  habits_per_week    :integer
+#  max_habits_per_day :integer          default(1), not null
+#  status             :string           default("open"), not null
+#  title              :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  team_id            :integer
 #
 
 class Streak < ApplicationRecord

--- a/app/resources/habit_resource.rb
+++ b/app/resources/habit_resource.rb
@@ -4,9 +4,15 @@ class HabitResource < ApplicationResource
   # Used for associating this resource with a given input.
   # This should match the 'type' in the corresponding serializer.
   type :habits
-  # Associate to a Model object so we know how to persist.
   model Habit
   # Customize your resource here. Some common examples:
+  def create(create_params)
+    create_params[:completed_at] = Time.zone.parse(create_params[:completed_at])
+    m = model.new(create_params)
+    m.save
+    m
+  end
+
   #
   # === Allow ?filter[name] query parameter ===
   # allow_filter :name

--- a/app/serializers/serializable_habit.rb
+++ b/app/serializers/serializable_habit.rb
@@ -1,0 +1,19 @@
+# Serializers define the rendered JSON for a model instance.
+# We use jsonapi-rb, which is similar to active_model_serializers.
+class SerializableHabit < JSONAPI::Serializable::Resource
+  type :players
+
+  # Add attributes here to ensure they get rendered, .e.g.
+  #
+  # attribute :name
+  #
+  # To customize, pass a block and reference the underlying @object
+  # being serialized:
+  #
+  # attribute :name do
+  #   @object.name.upcase
+  # end
+  attribute :player_id
+  attribute :streak_id
+  attribute :completed_at
+end

--- a/config/initializers/strong_resources.rb
+++ b/config/initializers/strong_resources.rb
@@ -35,6 +35,7 @@ StrongResources.configure do
     attribute :title, :string
     attribute :description, :string
     attribute :habits_per_week, :integer
+    attribute :max_habits_per_day, :integer
     attribute :status, :string
     attribute :activated_at, :timestamp
     attribute :completed_at, :timestamp
@@ -49,6 +50,7 @@ StrongResources.configure do
     attribute :uuid, :string
   end
   strong_resource :habit do
+    attribute :completed_at, :string
     attribute :streak_id, :integer
     attribute :player_id, :integer
   end

--- a/db/migrate/20180517041426_add_max_habits_per_day_to_streak.rb
+++ b/db/migrate/20180517041426_add_max_habits_per_day_to_streak.rb
@@ -1,0 +1,5 @@
+class AddMaxHabitsPerDayToStreak < ActiveRecord::Migration[5.2]
+  def change
+    add_column :streaks, :max_habits_per_day, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20180517041653_add_completed_at_to_habit.rb
+++ b/db/migrate/20180517041653_add_completed_at_to_habit.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToHabit < ActiveRecord::Migration[5.2]
+  def change
+    add_column :habits, :completed_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_15_042449) do
+ActiveRecord::Schema.define(version: 2018_05_17_041653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2018_05_15_042449) do
     t.integer "player_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "completed_at"
     t.index ["streak_id", "player_id"], name: "index_habits_on_streak_id_and_player_id"
   end
 
@@ -58,6 +59,7 @@ ActiveRecord::Schema.define(version: 2018_05_15_042449) do
     t.datetime "updated_at", null: false
     t.datetime "activated_at"
     t.datetime "completed_at"
+    t.integer "max_habits_per_day", default: 1, null: false
   end
 
   create_table "team_players", force: :cascade do |t|

--- a/spec/factories/habits.rb
+++ b/spec/factories/habits.rb
@@ -2,11 +2,12 @@
 #
 # Table name: habits
 #
-#  id         :bigint(8)        not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  player_id  :integer
-#  streak_id  :integer
+#  id           :bigint(8)        not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  player_id    :integer
+#  streak_id    :integer
 #
 # Indexes
 #
@@ -17,5 +18,6 @@ FactoryBot.define do
   factory :habit do
     streak_id 1
     player_id 1
+    completed_at Time.zone.now
   end
 end

--- a/spec/factories/streaks.rb
+++ b/spec/factories/streaks.rb
@@ -2,17 +2,18 @@
 #
 # Table name: streaks
 #
-#  id              :bigint(8)        not null, primary key
-#  activated_at    :datetime
-#  completed_at    :datetime
-#  description     :text
-#  ended_at        :datetime
-#  habits_per_week :integer
-#  status          :string           default("open"), not null
-#  title           :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  team_id         :integer
+#  id                 :bigint(8)        not null, primary key
+#  activated_at       :datetime
+#  completed_at       :datetime
+#  description        :text
+#  ended_at           :datetime
+#  habits_per_week    :integer
+#  max_habits_per_day :integer          default(1), not null
+#  status             :string           default("open"), not null
+#  title              :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  team_id            :integer
 #
 
 FactoryBot.define do

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: habits
 #
-#  id         :bigint(8)        not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  player_id  :integer
-#  streak_id  :integer
+#  id           :bigint(8)        not null, primary key
+#  completed_at :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  player_id    :integer
+#  streak_id    :integer
 #
 # Indexes
 #


### PR DESCRIPTION


  - To keep a user from completing all the week habits in one day it adds a max habits per day that
    defaults to 1 per day
  - Adds validation to the habit model
  - Adds a completed at field to habit to account for the difference of when a habit is completed
    and when it is created (important for offline habit completion)
  - TODO: look at converting strong parameter habit completed at time not in the habit resource but
    by a custom type