### PR TITLE
Adds ability to complete habit

### DIFF
--- a/app/controllers/current_player/active_streaks_controller.rb
+++ b/app/controllers/current_player/active_streaks_controller.rb
@@ -2,7 +2,7 @@ module CurrentPlayer
   class ActiveStreaksController < JsonapiApplicationController
     # Mark this as a JSONAPI controller, associating with the given resource
     include Concerns::PlayerSecured
-    jsonapi resource: ::StreakResource
+    jsonapi resource: ::CurrentPlayer::ActiveStreakResource
     strong_resource :streak do
       has_many :players
       has_many :habits
@@ -23,14 +23,21 @@ module CurrentPlayer
       instance = scope.resolve.first
       raise JsonapiCompliable::Errors::RecordNotFound unless instance
       raise Errors::NotAuthorized unless instance.players.include?(current_player)
-      render_jsonapi(instance, scope: false)
+      render_jsonapi(instance, {
+        include: {:habits => {}, :players => {}, :team => {}, :team_players => {}},
+        scope: false,
+      })
     end
 
     def update
       streak, success = jsonapi_update.to_a
 
       if success
-        render_jsonapi(streak, scope: false)
+        render_jsonapi(streak, {
+          include: {:habits => {}, :team => {}, :team_players => {}, :players =>{} },
+          no_force_includes: true,
+          scope: false
+        })
       else
         render_errors_for(streak)
       end

--- a/app/controllers/current_player/open_streaks_controller.rb
+++ b/app/controllers/current_player/open_streaks_controller.rb
@@ -58,6 +58,9 @@ module CurrentPlayer
       if new_player_count == Streak::MIN_PLAYERS
         team_uuid = streak.players.map(&:id).sort.join
         team = Team.find_or_create_by(uuid: team_uuid)
+        if team.team_players.count == 0
+          team.add_players(streak.players)
+        end
         streak.update!(team: team)
         streak.activate!
       end

--- a/app/controllers/current_player/streaks_controller.rb
+++ b/app/controllers/current_player/streaks_controller.rb
@@ -4,6 +4,7 @@ module CurrentPlayer
     jsonapi resource: StreakResource
     strong_resource :streak do
       has_many :players
+      has_many :habits
     end
 
     before_action :apply_strong_params, only: [:create, :update]

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -19,11 +19,16 @@ class Habit < ApplicationRecord
   belongs_to :streak
   validate :is_not_over_max_habits_per_day_for_streak
 
+  scope :current_week, -> { where('completed_at > ?', DateTime.now.beginning_of_week(:sunday)) }
+
   private
 
   def is_not_over_max_habits_per_day_for_streak
-    count_of_habits_for_player_today = streak.habits.where(player_id: player.id).where('completed_at between ? AND ?', completed_at.beginning_of_day, completed_at.end_of_day).count 
-    if count_of_habits_for_player_today >= streak.max_habits_per_day
+    count_of_habits_for_player_today = streak.habits.where(player_id: player.id).where('completed_at between ? AND ?', completed_at.beginning_of_day, completed_at.end_of_day)
+    if id.present?
+      count_of_habits_for_player_today = count_of_habits_for_player_today.where.not(id: id)
+    end
+    if count_of_habits_for_player_today.count >= streak.max_habits_per_day
       errors.add(:streak, "Can't add more than max habit per day for this streak")
     end
   end

--- a/app/models/streak.rb
+++ b/app/models/streak.rb
@@ -19,7 +19,8 @@
 class Streak < ApplicationRecord
   belongs_to :team, optional: true
   has_many :streak_players
-  has_many :habits
+  has_many :team_players, through: :team
+  has_many :habits, autosave: true
   has_many :players, through: :streak_players, after_add: :notify_on_player_add, after_remove: :notify_on_player_remove
 
   validates :status, :habits_per_week, :title,  presence: true
@@ -27,6 +28,7 @@ class Streak < ApplicationRecord
   validate :minimum_number_of_players_for_active_streak
   validate :minimum_number_of_players_for_open_streak
   validate :team_presence_for_active_streak
+  validates_associated :habits
 
   scope :active, -> { where(status: 'active') }
   scope :open, -> { where(status: 'open') }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -18,4 +18,19 @@ class Team < ApplicationRecord
   has_many :team_players
   has_many :players, through: :team_players
   has_many :streaks
+  DEFAULT_COLORS = [
+    "#1abc9c", # turquoise
+    "#FC427B", #pink
+    "#8e44ad", # purple
+    "#e67e22", #carrot
+    "#2980b9", #blue
+    "#B33771", #fuscia
+  ]
+
+  def add_players(players)
+    raise StandardError if players.count != 6
+    players.each_with_index do |player, i|
+      team_players << TeamPlayer.new(player: player, color: DEFAULT_COLORS[i])
+    end
+  end
 end

--- a/app/resources/current_player/active_streak_resource.rb
+++ b/app/resources/current_player/active_streak_resource.rb
@@ -1,5 +1,5 @@
 module CurrentPlayer
-  class StreakResource < ApplicationResource
+  class ActiveStreakResource < ApplicationResource
     type :streaks
     model Streak
 
@@ -7,24 +7,8 @@ module CurrentPlayer
       instance = model.find(update_params.delete(:id))
       instance.add_listener(context)
       instance.update_attributes(update_params)
-      instance.players << current_player
-      instance
-    end
-
-    def create(create_params)
-      m = model.new(create_params)
-      m.players << current_player
-      m.save
-      m
-    end
-
-    def destroy(id)
-      instance = model.find(id)
-      instance.add_listener(context)
-      instance.streak_players.find_by_player_id(current_player.id).destroy
-      if instance.players.count == 0
-        instance.destroy
-      end
+      instance.habits << Habit.new(player: current_player, completed_at: Time.zone.now)
+      instance.save
       instance
     end
 

--- a/app/resources/habit_resource.rb
+++ b/app/resources/habit_resource.rb
@@ -1,10 +1,14 @@
 # Define how to query and persist a given model.
-# Further Resource documentation: https://jsonapi-suite.github.io/jsonapi_compliable/JsonapiCompliable/Resource.html
 class HabitResource < ApplicationResource
   # Used for associating this resource with a given input.
   # This should match the 'type' in the corresponding serializer.
   type :habits
   model Habit
+
+  allow_filter :current_week do |scope|
+    scope.current_week
+  end
+
   # Customize your resource here. Some common examples:
   def create(create_params)
     create_params[:completed_at] = Time.zone.parse(create_params[:completed_at])
@@ -13,37 +17,8 @@ class HabitResource < ApplicationResource
     m
   end
 
-  #
-  # === Allow ?filter[name] query parameter ===
-  # allow_filter :name
-  #
-  # === Enable total count, when requested ===
-  # allow_stat total: [:count]
-  #
-  # === Allow sideloading/sideposting of relationships ===
-  # belongs_to :foo,
-  #   foreign_key: :foo_id,
-  #   resource: FooResource,
-  #   scope: -> { Foo.all }
-  #
-  # === Custom sorting logic ===
-  # sort do |scope, att, dir|
-  #   ... code ...
-  # end
-  #
-  # === Change default sort ===
-  # default_sort([{ title: :asc }])
-  #
-  # === Custom pagination logic ===
-  # paginate do |scope, current_page, per_page|
-  #   ... code ...
-  # end
-  #
-  # === Change default page size ===
-  # default_page_size(10)
-  #
-  # === Change how we resolve the scope ===
-  # def resolve(scope)
-  #   ... code ...
-  # end
+  belongs_to :streak,
+    scope: -> { Streak.all  },
+    resource: StreakResource,
+    foreign_key: :streak_id
 end

--- a/app/resources/team_player_resource.rb
+++ b/app/resources/team_player_resource.rb
@@ -1,0 +1,9 @@
+class TeamPlayerResource < ApplicationResource
+  type :team_players
+  model TeamPlayer
+
+  belongs_to :team,
+    scope: -> { Team.all  },
+    resource: TeamResource,
+    foreign_key: :team_id
+end

--- a/app/resources/team_resource.rb
+++ b/app/resources/team_resource.rb
@@ -1,0 +1,14 @@
+class TeamResource < ApplicationResource
+  type :teams
+  model Team
+
+  has_many :streaks,
+    scope: -> { Streak.all  },
+    resource: StreakResource,
+    foreign_key: :streak_id
+
+  has_many :team_players,
+    scope: -> { TeamPlayer.all },
+    resource: TeamPlayerResource,
+    foreign_key: :team_id
+end

--- a/app/serializers/serializable_habit.rb
+++ b/app/serializers/serializable_habit.rb
@@ -1,7 +1,6 @@
 # Serializers define the rendered JSON for a model instance.
-# We use jsonapi-rb, which is similar to active_model_serializers.
 class SerializableHabit < JSONAPI::Serializable::Resource
-  type :players
+  type :habits
 
   # Add attributes here to ensure they get rendered, .e.g.
   #
@@ -10,7 +9,7 @@ class SerializableHabit < JSONAPI::Serializable::Resource
   # To customize, pass a block and reference the underlying @object
   # being serialized:
   #
-  # attribute :name do
+  # attribute :color do
   #   @object.name.upcase
   # end
   attribute :player_id

--- a/app/serializers/serializable_streak.rb
+++ b/app/serializers/serializable_streak.rb
@@ -9,7 +9,14 @@ class SerializableStreak < JSONAPI::Serializable::Resource
   attribute :completed_at
   attribute :status
   attribute :habits_per_week
+  attribute :max_habits_per_day
   attribute :description
   attribute :title
+  attribute :total_habits_in_week do
+    @object.habits_per_week * @object.players.count
+  end
   has_many :players
+  has_many :habits
+  has_many :team_players
+  has_one :team
 end

--- a/app/serializers/serializable_team.rb
+++ b/app/serializers/serializable_team.rb
@@ -1,0 +1,8 @@
+class SerializableTeam < JSONAPI::Serializable::Resource
+  type :teams
+
+  attribute :name
+  attribute :uuid
+  attribute :created_at
+  has_many :team_players
+end

--- a/app/serializers/serializable_team_player.rb
+++ b/app/serializers/serializable_team_player.rb
@@ -1,0 +1,11 @@
+class SerializableTeamPlayer < JSONAPI::Serializable::Resource
+  type :team_players
+
+  attribute :user_name do
+    @object.player.user_name
+  end
+
+  attribute :player_id
+  attribute :team_id
+  attribute :color
+end

--- a/config/initializers/strong_resources.rb
+++ b/config/initializers/strong_resources.rb
@@ -45,6 +45,16 @@ StrongResources.configure do
     attribute :description, :string
     attribute :habits_per_week, :integer
   end
+  strong_resource :team do
+    attribute :uuid, :string
+    attribute :name, :string
+    attribute :created_at, :timestamp
+  end
+  strong_resource :team_player do
+    attribute :player_id, :integer
+    attribute :team_id, :integer
+    attribute :color, :string
+  end
   strong_resource :player do
     attribute :user_name, :string
     attribute :uuid, :string

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -15,8 +15,64 @@
 #
 
 require 'rails_helper'
-
-RSpec.describe Habit, type: :model do
+describe Habit, type: :model do
   it { is_expected.to belong_to(:player) }
   it { is_expected.to belong_to(:streak) }
+
+  describe "validate not over max habits per day" do
+    it "is valid when the habit is below the number of max habits per day" do
+      streak = create(:streak, :active, max_habits_per_day: 2)
+      streak_player = streak.players.last
+      first_habit_for_day = create(:habit, player: streak_player, streak: streak)
+
+      second_habit_for_day = create(:habit, player: streak_player, streak: streak)
+      expect(second_habit_for_day).to be_valid
+    end
+    it "is invalid when there habit is above the number of max habits per day" do
+      streak = create(:streak, :active, max_habits_per_day: 1)
+      streak_player = streak.players.last
+      first_habit_for_day = create(:habit, player: streak_player, streak: streak)
+
+      second_habit_for_day = build(:habit, player: streak_player, streak: streak)
+      expect(second_habit_for_day).not_to be_valid
+    end
+    it "is valid when it already created and under the number of max habits for the day" do
+      streak = create(:streak, :active, max_habits_per_day: 1)
+      streak_player = streak.players.last
+      first_habit_for_day = create(:habit, player: streak_player, streak: streak)
+
+      expect(first_habit_for_day).to be_valid
+    end
+  end
+
+  describe ".scopes" do
+    describe ".current_week" do
+      context "on a tuesday" do
+       let(:tuesday_july_3_at_noon) { Time.zone.local(2018, 7, 3, 12, 0, 0) }
+       let(:sunday_june_24th_beginning_of_day) { Time.zone.local(2018, 6, 24, 0, 0, 0) }
+        before do
+          Timecop.freeze(tuesday_july_3_at_noon)
+        end
+        after do
+          Timecop.return
+        end
+        it "returns only habits completed after start of streak week" do
+          streak = create(:streak, :active, activated_at: sunday_june_24th_beginning_of_day )
+          streak_player = streak.players.first
+          habit_from_prior_week = create(:habit, {
+            streak: streak,
+            player: streak_player,
+            completed_at: Time.zone.now - 1.week
+          })
+          habit_from_today = create(:habit, {
+            streak: streak,
+            player: streak_player,
+            completed_at: Time.zone.now
+          })
+
+          expect(described_class.current_week.to_a).to match_array([habit_from_today])
+        end
+      end
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -19,4 +19,14 @@ require 'rails_helper'
 describe Team, type: :model do
   it { is_expected.to have_many(:players).through(:team_players) }
   it { is_expected.to have_many(:streaks) }
+
+  describe "#add_players" do
+    it "adds players with default colors" do
+      active_streak = create(:streak, :active)
+      team = active_streak.team
+      team.add_players(active_streak.players)
+      expect(team.team_players.count).to eq(active_streak.players.count)
+      expect(team.team_players.map(&:color)).to match_array(Team::DEFAULT_COLORS)
+    end
+  end
 end


### PR DESCRIPTION
  - Adds a filter to the current player active streaks so to filter only habits from current week
 - Creates a CurrentPlayer::ActiveStreakResource that handles adding a habit to current streak to active streak without having to pass in anything but the streak itself
  - Fixes the show and update actions in the CurrentPlayer::ActiveStreakController to return all the required associations by default
  - Fixes bug in the habit validation checking for if habit is allowed for that day for that player by allowing already saved habits to be valid
  - add an add play method for the team model that adds new players and give them the default color values set in the class
  - create team_player and team resources 
  - Fixes but in serializable_habit to refer to habits instead of players
  - adds missing attributes from streak serializer
